### PR TITLE
Add altitude-based drag curve support

### DIFF
--- a/docs/user/rocket/rocket_usage.rst
+++ b/docs/user/rocket/rocket_usage.rst
@@ -81,8 +81,10 @@ The drag curves can be defined in two ways:
 2. Passing in a function that returns the drag coefficient given the Mach
    number.
 
-Curves defined in CSV files must have the first column as the Mach number
-and the second column as the drag coefficient.
+Curves defined in CSV files may contain two or three columns. If two columns
+are given, the first must be the Mach number and the second the drag
+coefficient. If three columns are provided, they must be Mach number,
+altitude in meters and drag coefficient, respectively.
 Here is an example of a drag curve file:
 
 .. code-block::
@@ -98,6 +100,15 @@ Here is an example of a drag curve file:
     0.8, 0.40110651
     0.9, 0.45696342
     1.0, 0.62744566
+
+For altitude based curves the file should look like:
+
+.. code-block::
+
+    0.0, 0, 0.5
+    0.0, 1000, 0.4
+    1.0, 0, 0.3
+    1.0, 1000, 0.2
 
 .. tip::
     Getting a drag curve can be a challenging task. To get really accurate

--- a/rocketpy/plots/rocket_plots.py
+++ b/rocketpy/plots/rocket_plots.py
@@ -103,36 +103,65 @@ class _RocketPlots:
         None
         """
 
-        try:
-            x_power_drag_on = self.rocket.power_on_drag.x_array
-            y_power_drag_on = self.rocket.power_on_drag.y_array
-        except AttributeError:
-            x_power_drag_on = np.linspace(0, 2, 50)
-            y_power_drag_on = np.array(
-                [self.rocket.power_on_drag.source(x) for x in x_power_drag_on]
-            )
-        try:
-            x_power_drag_off = self.rocket.power_off_drag.x_array
-            y_power_drag_off = self.rocket.power_off_drag.y_array
-        except AttributeError:
-            x_power_drag_off = np.linspace(0, 2, 50)
-            y_power_drag_off = np.array(
-                [self.rocket.power_off_drag.source(x) for x in x_power_drag_off]
+        if self.rocket.power_on_drag.get_domain_dim() == 2 or self.rocket.power_off_drag.get_domain_dim() == 2:
+            fig = plt.figure()
+            ax = fig.add_subplot(111, projection="3d")
+
+            def _plot_surface(func, color, label):
+                try:
+                    x = np.linspace(func.x_array.min(), func.x_array.max(), 30)
+                    y = np.linspace(func.y_array.min(), func.y_array.max(), 30)
+                except AttributeError:
+                    x = np.linspace(0, 2, 30)
+                    y = np.linspace(0, 2000, 30)
+                X, Y = np.meshgrid(x, y)
+                Z = np.array(func.get_value(X.flatten(), Y.flatten())).reshape(X.shape)
+                surf = ax.plot_surface(X, Y, Z, color=color, alpha=0.6, label=label)
+                return surf
+
+            surf_on = _plot_surface(self.rocket.power_on_drag, "C0", "Power on Drag")
+            surf_off = _plot_surface(self.rocket.power_off_drag, "C1", "Power off Drag")
+
+            ax.set_title("Drag Curves")
+            ax.set_xlabel("Mach Number")
+            ax.set_ylabel("Altitude (m)")
+            ax.set_zlabel("Drag Coefficient")
+            ax.legend(handles=[surf_on, surf_off])
+            show_or_save_plot(filename)
+        else:
+            try:
+                x_power_drag_on = self.rocket.power_on_drag.x_array
+                y_power_drag_on = self.rocket.power_on_drag.y_array
+            except AttributeError:
+                x_power_drag_on = np.linspace(0, 2, 50)
+                y_power_drag_on = np.array(
+                    [self.rocket.power_on_drag.source(x) for x in x_power_drag_on]
+                )
+            try:
+                x_power_drag_off = self.rocket.power_off_drag.x_array
+                y_power_drag_off = self.rocket.power_off_drag.y_array
+            except AttributeError:
+                x_power_drag_off = np.linspace(0, 2, 50)
+                y_power_drag_off = np.array(
+                    [self.rocket.power_off_drag.source(x) for x in x_power_drag_off]
+                )
+
+            _, ax = plt.subplots()
+            ax.plot(x_power_drag_on, y_power_drag_on, label="Power on Drag")
+            ax.plot(
+                x_power_drag_off,
+                y_power_drag_off,
+                label="Power off Drag",
+                linestyle="--",
             )
 
-        _, ax = plt.subplots()
-        ax.plot(x_power_drag_on, y_power_drag_on, label="Power on Drag")
-        ax.plot(
-            x_power_drag_off, y_power_drag_off, label="Power off Drag", linestyle="--"
-        )
-
-        ax.set_title("Drag Curves")
-        ax.set_ylabel("Drag Coefficient")
-        ax.set_xlabel("Mach")
-        ax.axvspan(0.8, 1.2, alpha=0.3, color="gray", label="Transonic Region")
-        ax.legend(loc="best", shadow=True)
-        plt.grid(True)
-        show_or_save_plot(filename)
+            ax.set_title("Drag Curves")
+            ax.set_ylabel("Drag Coefficient")
+            ax.set_xlabel("Mach")
+            ax.axvspan(0.8, 1.2, alpha=0.3, color="gray", label="Transonic Region")
+            ax.legend(loc="best", shadow=True)
+            plt.grid(True)
+            show_or_save_plot(filename)
 
     def thrust_to_weight(self):
         """

--- a/rocketpy/rocket/rocket.py
+++ b/rocketpy/rocket/rocket.py
@@ -240,13 +240,13 @@ class Rocket:
             entry to the Function class. See help(Function) for more
             information. If int or float is given, it is assumed constant. If
             callable, string or array is given, it must be a function of Mach
-            number only.
+            number or a function of Mach number and altitude.
         power_on_drag : int, float, callable, string, array
             Rocket's drag coefficient when the motor is on. Can be given as an
             entry to the Function class. See help(Function) for more
             information. If int or float is given, it is assumed constant. If
             callable, string or array is given, it must be a function of Mach
-            number only.
+            number or a function of Mach number and altitude.
         center_of_mass_without_motor : int, float
             Position, in m, of the rocket's center of mass without motor
             relative to the rocket's coordinate system. Default is 0, which
@@ -336,20 +336,33 @@ class Rocket:
         )
 
         # Define aerodynamic drag coefficients
-        self.power_off_drag = Function(
-            power_off_drag,
-            "Mach Number",
-            "Drag Coefficient with Power Off",
-            "linear",
-            "constant",
-        )
-        self.power_on_drag = Function(
-            power_on_drag,
-            "Mach Number",
-            "Drag Coefficient with Power On",
-            "linear",
-            "constant",
-        )
+        self.power_off_drag = Function(power_off_drag)
+        self.power_off_drag.set_interpolation("linear")
+        self.power_off_drag.set_extrapolation("constant")
+        dim_off = self.power_off_drag.get_domain_dim()
+        if dim_off == 1:
+            self.power_off_drag.set_inputs(["Mach Number"])
+        elif dim_off == 2:
+            self.power_off_drag.set_inputs(["Mach Number", "Altitude (m)"])
+        else:
+            raise TypeError(
+                "power_off_drag must depend on Mach number or Mach number and altitude"
+            )
+        self.power_off_drag.set_outputs("Drag Coefficient with Power Off")
+
+        self.power_on_drag = Function(power_on_drag)
+        self.power_on_drag.set_interpolation("linear")
+        self.power_on_drag.set_extrapolation("constant")
+        dim_on = self.power_on_drag.get_domain_dim()
+        if dim_on == 1:
+            self.power_on_drag.set_inputs(["Mach Number"])
+        elif dim_on == 2:
+            self.power_on_drag.set_inputs(["Mach Number", "Altitude (m)"])
+        else:
+            raise TypeError(
+                "power_on_drag must depend on Mach number or Mach number and altitude"
+            )
+        self.power_on_drag.set_outputs("Drag Coefficient with Power On")
 
         # Create a, possibly, temporary empty motor
         # self.motors = Components()  # currently unused, only 1 motor is supported

--- a/rocketpy/simulation/flight.py
+++ b/rocketpy/simulation/flight.py
@@ -1349,7 +1349,12 @@ class Flight:
             + (vz) ** 2
         ) ** 0.5
         free_stream_mach = free_stream_speed / self.env.speed_of_sound.get_value_opt(z)
-        drag_coeff = self.rocket.power_on_drag.get_value_opt(free_stream_mach)
+        if self.rocket.power_on_drag.get_domain_dim() == 2:
+            drag_coeff = self.rocket.power_on_drag.get_value_opt(
+                free_stream_mach, z
+            )
+        else:
+            drag_coeff = self.rocket.power_on_drag.get_value_opt(free_stream_mach)
 
         # Calculate Forces
         pressure = self.env.pressure.get_value_opt(z)
@@ -1520,9 +1525,23 @@ class Flight:
         # Determine aerodynamics forces
         # Determine Drag Force
         if t < self.rocket.motor.burn_out_time:
-            drag_coeff = self.rocket.power_on_drag.get_value_opt(free_stream_mach)
+            if self.rocket.power_on_drag.get_domain_dim() == 2:
+                drag_coeff = self.rocket.power_on_drag.get_value_opt(
+                    free_stream_mach, z
+                )
+            else:
+                drag_coeff = self.rocket.power_on_drag.get_value_opt(
+                    free_stream_mach
+                )
         else:
-            drag_coeff = self.rocket.power_off_drag.get_value_opt(free_stream_mach)
+            if self.rocket.power_off_drag.get_domain_dim() == 2:
+                drag_coeff = self.rocket.power_off_drag.get_value_opt(
+                    free_stream_mach, z
+                )
+            else:
+                drag_coeff = self.rocket.power_off_drag.get_value_opt(
+                    free_stream_mach
+                )
         rho = self.env.density.get_value_opt(z)
         R3 = -0.5 * rho * (free_stream_speed**2) * self.rocket.area * drag_coeff
         for air_brakes in self.rocket.air_brakes:
@@ -1797,10 +1816,24 @@ class Flight:
                 + self.rocket.motor.pressure_thrust(pressure),
                 0,
             )
-            drag_coeff = self.rocket.power_on_drag.get_value_opt(free_stream_mach)
+            if self.rocket.power_on_drag.get_domain_dim() == 2:
+                drag_coeff = self.rocket.power_on_drag.get_value_opt(
+                    free_stream_mach, z
+                )
+            else:
+                drag_coeff = self.rocket.power_on_drag.get_value_opt(
+                    free_stream_mach
+                )
         else:
             net_thrust = 0
-            drag_coeff = self.rocket.power_off_drag.get_value_opt(free_stream_mach)
+            if self.rocket.power_off_drag.get_domain_dim() == 2:
+                drag_coeff = self.rocket.power_off_drag.get_value_opt(
+                    free_stream_mach, z
+                )
+            else:
+                drag_coeff = self.rocket.power_off_drag.get_value_opt(
+                    free_stream_mach
+                )
         R3 += -0.5 * rho * (free_stream_speed**2) * self.rocket.area * drag_coeff
         for air_brakes in self.rocket.air_brakes:
             if air_brakes.deployment_level > 0:

--- a/rocketpy/stochastic/stochastic_model.py
+++ b/rocketpy/stochastic/stochastic_model.py
@@ -414,7 +414,7 @@ class StochasticModel:
         if input_value is not None:
             error_msg = (
                 f"`{input_name}` must be a list of path strings, lists "
-                "with shape (n,2), or Functions."
+                "with shape (n,2) or (n,3), or Functions."
             )
 
             if not isinstance(input_value, list):
@@ -422,7 +422,10 @@ class StochasticModel:
 
             for member in input_value:
                 if isinstance(member, list):
-                    if len(np.shape(member)) != 2 or np.shape(member)[1] != 2:
+                    if len(np.shape(member)) != 2 or np.shape(member)[1] not in (
+                        2,
+                        3,
+                    ):
                         raise AssertionError(error_msg)
                 elif not isinstance(member, (str, Function)):
                     raise AssertionError(error_msg)

--- a/tests/fixtures/rockets/rocket_fixtures.py
+++ b/tests/fixtures/rockets/rocket_fixtures.py
@@ -28,6 +28,29 @@ def calisto_motorless():
 
 
 @pytest.fixture
+def simple_rocket_2d_drag():
+    """Rocket with drag curves depending on Mach and altitude."""
+
+    table = np.array(
+        [
+            [0, 0, 0.5],
+            [0, 1000, 0.4],
+            [1, 0, 0.3],
+            [1, 1000, 0.2],
+        ]
+    )
+
+    return Rocket(
+        radius=0.05,
+        mass=10,
+        inertia=(1, 1, 1),
+        power_off_drag=table,
+        power_on_drag=table,
+        center_of_mass_without_motor=0,
+    )
+
+
+@pytest.fixture
 def calisto(calisto_motorless, cesaroni_m1670):  # old name: rocket
     """Create a simple object of the Rocket class to be used in the tests. This
     is the same rocket that has been used in the getting started guide for

--- a/tests/unit/stochastic/test_stochastic_rocket.py
+++ b/tests/unit/stochastic/test_stochastic_rocket.py
@@ -23,3 +23,14 @@ def test_create_object(stochastic_calisto):
     """
     obj = stochastic_calisto.create_object()
     assert isinstance(obj, Rocket)
+
+
+def test_validate_drag_table(simple_rocket_2d_drag):
+    from rocketpy.stochastic import StochasticRocket
+
+    table = [[0, 0, 0.5], [1, 1000, 0.4]]
+    rocket = StochasticRocket(
+        rocket=simple_rocket_2d_drag,
+        power_on_drag=[table],
+    )
+    assert isinstance(rocket, StochasticRocket)

--- a/tests/unit/test_flight.py
+++ b/tests/unit/test_flight.py
@@ -628,3 +628,25 @@ def test_stability_static_margins(
         assert np.all(moments / wind_sign <= 0)
     else:  # static_margin == 0
         assert np.all(np.abs(moments) <= 1e-10)
+
+
+def test_flight_drag_uses_altitude(simple_rocket_2d_drag, example_plain_env):
+    flight = Flight(
+        environment=example_plain_env,
+        rocket=simple_rocket_2d_drag,
+        rail_length=1,
+        inclination=90,
+        heading=0,
+        terminate_on_apogee=False,
+    )
+
+    record = []
+
+    def drag(mach, alt):
+        record.append((mach, alt))
+        return 0.3
+
+    simple_rocket_2d_drag.power_on_drag.set_source(drag)
+    state = [0, 0, 1000, 10, 0, 0, 1, 0, 0, 0, 0, 0, 0]
+    flight.udot_rail1(0, state)
+    assert record[-1][1] == 1000

--- a/tests/unit/test_rocket.py
+++ b/tests/unit/test_rocket.py
@@ -655,3 +655,9 @@ def test_coordinate_system_orientation(
     static_margin_nose_to_tail = rocket_nose_to_tail.static_margin
 
     assert np.array_equal(static_margin_tail_to_nose, static_margin_nose_to_tail)
+
+
+def test_rocket_init_with_2d_drag(simple_rocket_2d_drag):
+    assert simple_rocket_2d_drag.power_on_drag.get_domain_dim() == 2
+    cd = simple_rocket_2d_drag.power_on_drag.get_value_opt(1, 1000)
+    assert cd == pytest.approx(0.2)


### PR DESCRIPTION
## Summary
- allow drag curves to depend on altitude
- update `Rocket` and `Flight` to handle 2‑D drag functions
- validate 3‑column drag data in stochastic rockets
- plot 3‑D drag surfaces when altitude data is provided
- document new CSV layout and add tests

## Testing
- `pytest tests/unit/test_rocket.py::test_rocket_init_with_2d_drag -q`
- `pytest tests/unit/test_flight.py::test_flight_drag_uses_altitude -q`
- `pytest tests/unit/stochastic/test_stochastic_rocket.py::test_validate_drag_table -q`


------
https://chatgpt.com/codex/tasks/task_e_686abfed1ae8832e95131f887cd1d9af